### PR TITLE
New Strategy for Gamer -- cannot pass through borders.

### DIFF
--- a/src/model/CannotPassBorderStrategy.java
+++ b/src/model/CannotPassBorderStrategy.java
@@ -16,14 +16,14 @@ import view.GamePanel;
 public class CannotPassBorderStrategy implements Strategy {
 
     // TODO: Add this to GameFigure instead of a class-by-class basis
-    private final int HEIGHT = 20;
-    private final int WIDTH = 20;
+    private final int HEIGHT = 100;
+    private final int WIDTH = 75;
     
     public CannotPassBorderStrategy(){
         
     }
     
-    // NOTE ------------------------------------------------------
+    // NOTE ---------------------- RTFM -----------------------------
     // This strategy takes the future positional increment
     // then determines which direction it object is going
     // (THIS DOESN'T WORK WITH DIAGONAL DIRECTIONS!!!!!).

--- a/src/model/GameData.java
+++ b/src/model/GameData.java
@@ -41,7 +41,7 @@ public class GameData {
         // we cannot use GamePanel.width and height.
         shooter = new Shooter(Main.WIN_WIDTH / 2, Main.WIN_HEIGHT - 150);
 
-        friendFigures.add(shooter);
+        //friendFigures.add(shooter);
 
         borders.add(new Border(-51, 0, 50, Main.WIN_HEIGHT)); // left border
         borders.add(new Border(0, -51, Main.WIN_WIDTH, 50)); // top border
@@ -199,7 +199,7 @@ public class GameData {
     }
     
     private void generateBorders(){
-        borders.add(new Border(150, 0, 100, 20));
-        borders.add(new Border(500, Main.WIN_HEIGHT-28 - 50, 35, 50));
+        borders.add(new Border(400, 0, 100, 50));
+        borders.add(new Border(700, Main.WIN_HEIGHT-28 - 50, 35, 50));
     }
 }

--- a/src/model/Shooter.java
+++ b/src/model/Shooter.java
@@ -24,7 +24,7 @@ public class Shooter extends GameFigureWithHealth
     {
         super(x, y);
         super.state = new StrongFigureState();
-        //strategy = new MonsterWalkingStrategy();
+        movement = new CannotPassBorderStrategy();
         BufferedImage[] movingUp = {Sprite.getSprite(PATH, 0), Sprite.getSprite(PATH, 1), Sprite.getSprite(PATH, 2), 
                                     Sprite.getSprite(PATH, 3), Sprite.getSprite(PATH, 4) };
         BufferedImage[] movingDown = {Sprite.getSprite(PATH, 5), Sprite.getSprite(PATH, 6), Sprite.getSprite(PATH, 7),
@@ -48,8 +48,7 @@ public class Shooter extends GameFigureWithHealth
     }
     
     public void translate(int x, int y){
-        this.x += x;
-        this.y += y;
+        movement.move(x, y, this);
     }
     
     public void shoot(int targetX, int targetY){
@@ -66,7 +65,7 @@ public class Shooter extends GameFigureWithHealth
     @Override
     public void update()
     {
-
+        
     }
     
     public void setAnimation(SpriteAnimation animation, SpriteAnimation newAnimation)


### PR DESCRIPTION
Changed Gamer's strategy so it can no longer pass borders. Removed Gamer from the general friend array list so that it doesn't destroy health enemies with its body. Set the updated width and height values for the CannotPassBorderStratedy to match Gamer's shooter (as there is no way to set width and height besides hard coding it atm).

(c+p commit msg...)